### PR TITLE
Add twitch override for ljl-japan

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ OVERRIDES = {
     "https://lolesports.com/live/cblol_academy":"https://lolesports.com/live/cblol_academy/cblol",
     "https://lolesports.com/live/cblol":"https://lolesports.com/live/cblol/cblol",
     "https://lolesports.com/live/lla":"https://lolesports.com/live/lla/lla"
+    "https://lolesports.com/live/ljl-japan/ljl":"https://lolesports.com/live/ljl-japan/riotgamesjp"
 }
 
 def createWebdriver(browser, headless):


### PR DESCRIPTION
To hopefully fix the following:

INFO: 2022/08/12 14:15:00 - ljl-japan is not eligible for rewards. Retrying...
WARNING: 2022/08/12 14:15:17 - ljl-japan is not eligible for rewards
WARNING: 2022/08/12 14:15:27 - Cannot set the Twitch player quality. Is the match on Twitch?