### PR TITLE
Fix wording for live matches count

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,7 +214,10 @@ while True:
     driver.get("https://lolesports.com/schedule")
     time.sleep(5)
     liveMatches = getLiveMatches(driver)
-    log.info(f"There are {len(liveMatches)} matches live")
+    if len(liveMatches) == 1:
+        log.info(f"There is 1 match live")
+    else:
+        log.info(f"There are {len(liveMatches)} matches live")
 
     # Close windows finished matches
     toRemove = []


### PR DESCRIPTION
This pr fixes wording in the case when there is only one match live:

![image](https://user-images.githubusercontent.com/23432278/187036031-0910de26-afdf-482a-ab10-856f6030afb4.png)

![image](https://user-images.githubusercontent.com/23432278/187036030-f1fad1b2-2dcc-40f1-a483-ced648b9ff09.png)

![image](https://user-images.githubusercontent.com/23432278/187036037-e078ca5d-5e16-43f1-a526-8d13c18853bc.png)
