### PR TITLE
Fixing missing arguments

### DIFF
--- a/EsportsCapsuleFarmer/Rewards.py
+++ b/EsportsCapsuleFarmer/Rewards.py
@@ -9,7 +9,7 @@ class Rewards:
         self.driver = driver
         pass
 
-    def findRewardsCheckmark(self):
+    def findRewardsCheckmark(self, driver):
         """
         Checks if the user is currently eligible to receive rewards.
         """


### PR DESCRIPTION
Fixed a missing argument that caused this
![WindowsTerminal_Q5r1](https://user-images.githubusercontent.com/57844715/194956790-3f5e65e6-c88b-4699-ac4b-8afb7ff995ee.png)
crash

not really sure if its that reason for the crash but it works ^^

